### PR TITLE
[#29] Automate typedoc publish

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@ Brief summary of PR purpose and code changes.
 ## CheckList
 
 - [ ] PR starts with [#_ISSUE_ID_].
-- [ ] Has been tested (where required) before merge to develop.
+- [ ] Has been tested (where required) before merge to main.

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,30 @@
+name: Publish TypeDocs
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install deps
+        run: make deps
+      - name: Use Deno v1.1.1
+        uses: denolib/setup-deno@master
+        with:
+          deno-version: 1.1.1
+      - run: make typedoc
+      - run: make ci
+      - name: Publish Updated Type Docs
+        uses: github-actions-x/commit@v2.6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-branch: "main"
+          commit-message: "publish typedocs"

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  publish-docs:
     runs-on: ubuntu-latest
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: benchmark build ci doc fmt fmt-check lock precommit test typedoc
+.PHONY: benchmark build ci deps doc fmt fmt-check lock test typedoc
 
 benchmark:
 	@./benchmarks/run.sh 1 ./benchmarks/middleware.ts
@@ -19,6 +19,9 @@ ci:
 	@make build
 	@make test
 
+deps:
+	@npm install -g typescript typedoc
+
 doc:
 	@deno doc ./mod.ts
 
@@ -31,14 +34,12 @@ fmt-check:
 lock:
 	@deno run --lock=lock.json --lock-write --reload mod.ts
 
-precommit:
-	@make typedoc
-	@make fmt
-	@make lock
-
 test:
 	@deno test --allow-net --allow-read ./test/units/
 
 typedoc:
-	@typedoc --ignoreCompilerErrors --out ./docs --mode modules --includeDeclarations --excludeExternals ./src
-
+	@rm -rf docs
+	@typedoc --ignoreCompilerErrors --out ./docs --mode modules --includeDeclarations --excludeExternals --name opine ./src
+	@make fmt
+	@make fmt
+	@echo 'future: true\nencoding: "UTF-8"\ninclude:\n  - "_*_.html"\n  - "_*_.*.html"' > ./docs/_config.yaml

--- a/repro-example/deps.ts
+++ b/repro-example/deps.ts
@@ -1,0 +1,3 @@
+export { serve } from "https://deno.land/std@0.58.0/http/server.ts";
+export { Status } from "https://deno.land/std@0.56.0/http/http_status.ts";
+export { encodeUrl } from "https://deno.land/x/encodeurl@1.0.0/mod.ts";


### PR DESCRIPTION
# Issue

[#29](https://github.com/asos-craigmorten/opine/issues/29)

## Details

Adds workflow + makefile updates in order to handle typedoc updates automatically.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [ ] Has been tested (where required) before merge to develop.
