### PR TITLE
[#22] Add res.redirect API

### DIFF
--- a/.github/API/response.md
+++ b/.github/API/response.md
@@ -334,6 +334,59 @@ app.get("/redirect", function (req, res, next) {
 });
 ```
 
+#### res.redirect([status], url)
+
+Redirects to the URL derived from the specified `path`, with specified `status`, a positive integer
+that corresponds to an [HTTP status code](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) .
+If not specified, `status` defaults to "302 "Found".
+
+```typescript
+res.redirect('/foo/bar')
+res.redirect('http://example.com')
+res.redirect(301, 'http://example.com')
+```
+Redirects can be a fully-qualified URL for redirecting to a different site:
+
+```typescript
+res.redirect('http://google.com')
+```
+Redirects can be relative to the root of the host name. For example, if the
+application is on `http://example.com/admin/post/new`, the following
+would redirect to the URL `http://example.com/admin`:
+
+```typescript
+res.redirect('/admin')
+```
+
+Redirects can be relative to the current URL. For example,
+from `http://example.com/blog/admin/` (notice the trailing slash), the following
+would redirect to the URL `http://example.com/blog/admin/post/new`.
+
+```typescript
+res.redirect('post/new')
+```
+
+Redirecting to `post/new` from `http://example.com/blog/admin` (no trailing slash),
+will redirect to `http://example.com/blog/post/new`.
+
+If you found the above behavior confusing, think of path segments as directories
+(with trailing slashes) and files, it will start to make sense.
+
+Path-relative redirects are also possible. If you were on
+`http://example.com/admin/post/new`, the following would redirect to
+`http://example.com/admin/post`:
+
+```typescript
+res.redirect('..')
+```
+
+A `back` redirection redirects the request back to the [referer](http://en.wikipedia.org/wiki/HTTP_referer),
+defaulting to `/` when the referer is missing.
+
+```typescript
+res.redirect('back')
+```
+
 #### res.render(view [, locals][, callback])
 
 Renders a `view` and sends the rendered HTML string to the client. Optional parameters:

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ This directory contains a series of self-contained examples that you can use as 
 - [hello-world](./hello-world) - A basic example of how to configure and start an Opine server.
 - [json](./json) - An example of how to use the `json` body-parser middleware in your Opine applications.
 - [location](./location) - An example of how set the `Location` header using `res.location()` for a `301` redirect.
+- [redirect](./redirect) - An example of how to redirect using `res.redirect`.
 - [multi-router](./multi-router) - An example of how to use the Opine `Router` to mount several controllers onto a path within an application / API.
 - [proxy](./proxy) - Example using `opine-http-proxy` as a proxy middleware.
 - [raw](./raw) - An example of how to use the `raw` body-parser middleware in your Opine applications.

--- a/examples/redirect/README.md
+++ b/examples/redirect/README.md
@@ -1,6 +1,6 @@
 # redirect
 
-An example of how redirect using `res.redirect`.
+An example of how to redirect using `res.redirect`.
 
 ## How to run this example
 

--- a/examples/redirect/README.md
+++ b/examples/redirect/README.md
@@ -1,0 +1,19 @@
+# redirect
+
+An example of how redirect using `res.redirect`.
+
+## How to run this example
+
+Run this example using:
+
+```bash
+deno run --allow-net --allow-read ./examples/redirect/index.ts
+```
+
+if have the repo cloned locally _OR_
+
+```bash
+deno run --allow-net --allow-read https://raw.githubusercontent.com/asos-craigmorten/opine/main/examples/redirect/index.ts
+```
+
+if you don't!

--- a/examples/redirect/index.ts
+++ b/examples/redirect/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Run this example using:
+ * 
+ *    deno run --allow-net --allow-read ./examples/redirect/index.ts
+ * 
+ *    if have the repo cloned locally OR
+ * 
+ *    deno run --allow-net --allow-read https://raw.githubusercontent.com/asos-craigmorten/opine/main/examples/redirect/index.ts
+ * 
+ *    if you don't!
+ * 
+ */
+
+import opine from "../../mod.ts";
+
+const app = opine();
+
+app.get("/home", function (req, res) {
+  res.send("Hello Deno!");
+});
+
+// Redirects from `/redirect` to `/home` using a permanent redirect.
+//
+// To learn more about the Location header, please refer to
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Location
+app.get("/redirect", function (req, res) {
+  const status = 301;
+  res.redirect(status, `/home?status=${status}`);
+});
+
+// Redirects from `/relative/redirect/` to `/home` using:
+// 1. a temporary redirect
+// 2. a relative location.
+app.get("/relative/redirect", function (req, res) {
+  res.redirect("../home?status=302");
+});
+
+// You can call listen the same as Express with just
+// a port: `app.listen(3000)`, or with any arguments
+// that the Deno `http.serve` methods accept. Namely
+// an address string, HttpOptions or HttpsOptions
+// objects.
+app.listen({ port: 3000 });
+console.log("Opine started on port 3000");
+console.log(
+  `Try opening http://localhost:3000/redirect or http://localhost:3000/relative/redirect`,
+);

--- a/src/response.ts
+++ b/src/response.ts
@@ -456,7 +456,7 @@ export class Response implements DenoResponse {
       },
 
       html: function _renderRedirectHtmlBoby() {
-        var u = escapeHtml(address);
+        const u = escapeHtml(address);
         body = `<p>${
           STATUS_TEXT.get(status)
         }. Redirecting to <a href="${u}">${u}</a></p>`;

--- a/src/response.ts
+++ b/src/response.ts
@@ -428,7 +428,6 @@ export class Response implements DenoResponse {
     let address: string;
     let body: string = "";
     let status: Status;
-    let contentLength: string = "0";
 
     if (arguments.length === 0) {
       throw new TypeError("res.redirect: requires a location url");
@@ -469,12 +468,6 @@ export class Response implements DenoResponse {
 
     // Respond
     this.status = status;
-
-    if (body.length > 0) {
-      contentLength = new TextEncoder().encode(body).length + "";
-    }
-
-    this.set("content-length", contentLength);
 
     if (this.req.method === "HEAD") {
       this.end();

--- a/src/response.ts
+++ b/src/response.ts
@@ -10,6 +10,7 @@ import {
   extname,
   contentType,
   vary,
+  escapeHtml,
   encodeUrl,
 } from "../deps.ts";
 import {
@@ -404,7 +405,83 @@ export class Response implements DenoResponse {
     return this.set("Location", encodeUrl(loc));
   }
 
-  // TODO: redirect() {}
+  /**
+ * Redirect to the given `url` with optional response `status`
+ * defaulting to `302`.
+ *
+ * The resulting `url` is determined by `res.location()`.
+ * 
+ * Examples:
+ *
+ *    res.redirect('/foo/bar');
+ *    res.redirect('http://example.com');
+ *    res.redirect(301, 'http://example.com');
+ *    res.redirect('../login'); // /blog/post/1 -> /blog/login
+ *
+ * @param {Status} statusCode
+ * @param {string} url
+ * @public
+ */
+  redirect(url: string): void;
+  redirect(statusCode: Status, url: string): void;
+  redirect() {
+    let address: string;
+    let body: string = "";
+    let status: Status;
+    let contentLength: string = "0";
+
+    if (arguments.length === 0) {
+      throw new TypeError("res.redirect: requires a location url");
+    } else if (arguments.length === 1) {
+      address = arguments[0] + "";
+      status = 302;
+    } else {
+      if (typeof arguments[0] !== "number" || Number.isNaN(arguments[0])) {
+        throw new TypeError(
+          "res.redirect: expected status code to be a valid number",
+        );
+      }
+
+      address = arguments[1] + "";
+      status = arguments[0];
+    }
+
+    // Set location header
+    address = this.location(address).get("Location");
+
+    // Support text/{plain,html} by default
+    this.format({
+      text: function _renderRedirectBody() {
+        body = `${STATUS_TEXT.get(status)}. Redirecting to ${address}`;
+      },
+
+      html: function _renderRedirectHtmlBoby() {
+        var u = escapeHtml(address);
+        body = `<p>${
+          STATUS_TEXT.get(status)
+        }. Redirecting to <a href="${u}">${u}</a></p>`;
+      },
+
+      default: function _renderDefaultRedirectBody() {
+        body = "";
+      },
+    });
+
+    // Respond
+    this.status = status;
+
+    if (body.length > 0) {
+      contentLength = new TextEncoder().encode(body).length + "";
+    }
+
+    this.set("content-length", contentLength);
+
+    if (this.req.method === "HEAD") {
+      this.end();
+    } else {
+      this.end(body);
+    }
+  }
 
   /**
    * Render `view` with the given `options` and optional callback `fn`.

--- a/src/types.ts
+++ b/src/types.ts
@@ -709,6 +709,26 @@ export interface Response<ResBody = any>
   location(url: string): this;
 
   /**
+  * Redirect to the given `url` with optional response `status`
+  * defaulting to `302`.
+  *
+  * The resulting `url` is determined by `res.location()`.
+  *
+  * Examples:
+  *
+  *    res.redirect('/foo/bar');
+  *    res.redirect('http://example.com');
+  *    res.redirect(301, 'http://example.com');
+  *    res.redirect('../login'); // /blog/post/1 -> /blog/login
+  *
+  * @param {Status} statusCode
+  * @param {string} url
+  * @public
+  */
+  redirect(url: string): void;
+  redirect(code: Status, url: string): void;
+
+  /**
    * Render `view` with the given `options` and optional callback `fn`.
    * When a callback function is given a response will _not_ be made
    * automatically, otherwise a response of _200_ and _text/html_ is given.

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,2 +1,10 @@
 export { expect } from "https://deno.land/x/expect@285caf/mod.ts";
-export { superdeno } from "https://deno.land/x/superdeno@1.5.0/mod.ts";
+export {
+  superdeno,
+  IResponse as SuperDenoResponse,
+  IRequest as SuperDenoRequest,
+} from "https://deno.land/x/superdeno@1.5.0/mod.ts";
+export {
+  deferred,
+  Deferred,
+} from "https://deno.land/std@0.59.0/async/deferred.ts";

--- a/test/units/res.redirect.test.ts
+++ b/test/units/res.redirect.test.ts
@@ -1,0 +1,373 @@
+import opine from "../../mod.ts";
+import { describe, it, pick, omit } from "../utils.ts";
+import {
+  superdeno,
+  expect,
+  SuperDenoResponse,
+  deferred,
+  Deferred,
+} from "../deps.ts";
+import { Response, Request, Handler } from "../../src/types.ts";
+
+type DeferredTestResult = Deferred<
+  {
+    status?: number;
+    location?: string | null;
+    contentType?: string | null;
+    contentLength?: string | null;
+    body: string | null;
+  }
+>;
+
+function createRedirectMiddleware(
+  redirectArgs: any[],
+  deferredPromise: DeferredTestResult,
+): Handler {
+  return function redirectMiddleware(req, res, next) {
+    (res.redirect as any)(...redirectArgs);
+
+    let contentLength = null;
+    // Does not support Deno.Reader.
+    let body: string | null = null;
+
+    if (typeof res.body === "string") {
+      body = res.body;
+      contentLength = new TextEncoder().encode(body).length + "";
+    } else if (res.body instanceof Uint8Array) {
+      body = new TextDecoder().decode(res.body);
+      contentLength = res.body.length + "";
+    }
+
+    // It's not currently possible to not follow redirects in superdeno:
+    // https://github.com/asos-craigmorten/superdeno/issues/6
+    deferredPromise.resolve({
+      status: res.status,
+      location: res.headers?.get("location"),
+      contentType: res.headers?.get("content-type"),
+      contentLength,
+      body: typeof body === "string" ? body : null,
+    });
+  };
+}
+
+function handleRedirectTarget(req: Request, res: Response) {
+  res.json({ url: req.originalUrl, query: req.query });
+}
+
+function shouldNotHaveBody() {
+  return function (res: SuperDenoResponse) {
+    expect(res.text === "" || res.text == null).toBe(true);
+  };
+}
+
+describe("res", function () {
+  describe(".redirect(url)", function () {
+    it("should default to a 302 redirect", async function (done) {
+      const location = "/to";
+      const app = opine();
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .expect(200, { url: "/to", query: {} }, done);
+
+      expect(pick(await output, ["status", "location"])).toEqual({
+        status: 302,
+        location,
+      });
+    });
+
+    it('should encode "url"', async function (done) {
+      const app = opine();
+      const location = "/to?q=\u2603 §10";
+      const escapedLocation = "/to?q=%E2%98%83%20%C2%A710";
+      const locationSearchParams = new URLSearchParams(
+        location.slice(location.indexOf("?")),
+      );
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .expect(
+          200,
+          {
+            url: escapedLocation,
+            query: { q: locationSearchParams.get("q") },
+          },
+          done,
+        );
+
+      expect(pick(await output, ["status", "location"])).toEqual({
+        status: 302,
+        location: escapedLocation,
+      });
+    });
+
+    it('should not touch already-encoded sequences in "url"', async function (
+      done,
+    ) {
+      const app = opine();
+      const location = "/to?q=%20%20deno%26";
+      const locationSearchParams = new URLSearchParams(
+        location.slice(location.indexOf("?")),
+      );
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .expect(200, {
+          url: location,
+          query: { q: locationSearchParams.get("q") },
+        }, done);
+
+      expect(pick(await output, ["status", "location"])).toEqual({
+        status: 302,
+        location,
+      });
+    });
+  });
+
+  describe(".redirect(status, url)", function () {
+    it("should set the response status", async function (done) {
+      const app = opine();
+      const expectedStatus = 303;
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+
+      app.use(
+        "/from",
+        createRedirectMiddleware([expectedStatus, location], output),
+      );
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .expect(200, { url: location, query: {} }, done);
+
+      expect(pick(await output, ["status", "location"])).toEqual({
+        status: expectedStatus,
+        location,
+      });
+    });
+
+    it("should throw exception (500) if the first arg is not a number", async function (
+      done,
+    ) {
+      const app = opine();
+      const expectedStatus = "303";
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+
+      app.use(
+        "/from",
+        createRedirectMiddleware([expectedStatus, location], output),
+      );
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .expect(500, done);
+    });
+  });
+
+  describe("when url is back", function () {
+    it("should redirect to the referrer header", async function (done) {
+      const app = opine();
+      const location = "back";
+      const output: DeferredTestResult = deferred();
+      const referrer = "/to?referrer=ok";
+
+      app.use("/from", createRedirectMiddleware(["back"], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Referrer", referrer)
+        .expect(200, { url: referrer, query: { referrer: "ok" } }, done);
+
+      expect(pick(await output, ["status", "location"])).toEqual({
+        status: 302,
+        location: referrer,
+      });
+    });
+  });
+
+  describe("when the request method is HEAD", function () {
+    it("should ignore the body", function (done) {
+      const app = opine();
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .head("/from")
+        .expect(shouldNotHaveBody())
+        .expect(200, done);
+    });
+  });
+
+  describe("when accepting html", function () {
+    it("should respond with html", async function (done) {
+      const app = opine();
+      const expectedStatus = 307;
+      const expectedBody =
+        '<p>Temporary Redirect. Redirecting to <a href="/to">/to</a></p>';
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+
+      app.use(
+        "/from",
+        createRedirectMiddleware([expectedStatus, location], output),
+      );
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Accept", "text/html")
+        .expect(200, { url: location, query: {} }, done);
+
+      expect(await output).toEqual({
+        status: expectedStatus,
+        location,
+        contentLength: "63",
+        contentType: "text/html; charset=utf-8",
+        body: expectedBody,
+      });
+    });
+
+    it("should escape the url and include the redirect type", async function (
+      done,
+    ) {
+      const app = opine();
+      const location = "/<la'me>";
+      const expectedBody =
+        `<p>Found. Redirecting to <a href="/%3Cla&#39;me%3E">/%3Cla&#39;me%3E</a></p>`;
+      const escapedLocation = "/%3Cla'me%3E";
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/*", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Host", "http://example.com")
+        .set("Accept", "text/html")
+        .expect(200, { url: escapedLocation, query: {} }, done);
+
+      expect(omit(await output, ["contentLength"])).toEqual({
+        status: 302,
+        location: escapedLocation,
+        contentType: "text/html; charset=utf-8",
+        body: expectedBody,
+      });
+    });
+  });
+
+  describe("when accepting text", function () {
+    it("should respond with text", async function (done) {
+      const app = opine();
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Accept", "text/plain, */*")
+        .expect(200, { url: location, query: {} }, done);
+
+      expect(await output).toEqual({
+        status: 302,
+        location,
+        contentLength: "25",
+        contentType: "text/plain; charset=utf-8",
+        body: "Found. Redirecting to /to",
+      });
+    });
+
+    it("should encode the url", async function (done) {
+      const app = opine();
+      const location = `/to?param=<script>alert("hax");</script>`;
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Host", "http://example.com")
+        .set("Accept", "text/plain, */*")
+        .expect(200, done);
+
+      expect(omit(await output, ["contentLength"])).toEqual({
+        status: 302,
+        location: "/to?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E",
+        contentType: "text/plain; charset=utf-8",
+        body:
+          "Found. Redirecting to /to?param=%3Cscript%3Ealert(%22hax%22);%3C/script%3E",
+      });
+    });
+
+    it("should include the redirect type", async function (done) {
+      const app = opine();
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+      const expectedBody = "Moved Permanently. Redirecting to /to";
+
+      app.use("/from", createRedirectMiddleware([301, location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Accept", "text/plain, */*")
+        .expect(200, done);
+
+      expect(omit(await output, ["contentLength"])).toEqual({
+        status: 301,
+        location,
+        contentType: "text/plain; charset=utf-8",
+        body: expectedBody,
+      });
+    });
+  });
+
+  describe("when accepting neither text or html", function () {
+    it("should respond with an empty body", async function (done) {
+      const app = opine();
+      const location = "/to";
+      const output: DeferredTestResult = deferred();
+
+      app.use("/from", createRedirectMiddleware([301, location], output));
+      app.use("/to", handleRedirectTarget);
+
+      superdeno(app)
+        .get("/from")
+        .set("Accept", "application/octet-stream")
+        .expect(200, { url: "/to", query: {} }, done);
+
+      const resolvedOutput = await output;
+
+      expect(pick(resolvedOutput, ["status", "contentLength"])).toEqual({
+        status: 301,
+        contentLength: "0",
+      });
+
+      expect(resolvedOutput.contentType == null).toBe(true);
+      expect(resolvedOutput.body == null || resolvedOutput.body === "").toBe(
+        true,
+      );
+    });
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -75,3 +75,40 @@ export const after = (count: number, done: Function) => {
     }
   };
 };
+
+/**
+ * Returns an object subset of `obj`, whose properties are in `keys`.
+ * @param obj 
+ * @param props 
+ */
+export function pick<
+  T extends Object,
+  K extends keyof T,
+>(obj: T, keys: K[]): Pick<T, K> {
+  const output = {} as Pick<T, K>;
+
+  for (const key of keys) {
+    output[key] = obj[key];
+  }
+
+  return output;
+}
+
+/**
+ * Returns an object subset of `obj`, whose properties are not in `keys`.
+ * @param obj 
+ * @param keys 
+ */
+export function omit<T extends Object, K extends keyof T>(
+  obj: T,
+  keys: K[],
+): Omit<T, K> {
+  const copy = Object.create(Object.getPrototypeOf(obj));
+  Object.defineProperties(copy, Object.getOwnPropertyDescriptors(obj));
+
+  for (const key of keys) {
+    delete copy[key];
+  }
+
+  return copy as Omit<T, K>;
+}


### PR DESCRIPTION
References:

* issue: https://github.com/asos-craigmorten/opine/issues/22

* express docs: https://expressjs.com/en/4x/api.html#res.redirect

# Issue

[#22](https://github.com/asos-craigmorten/opine/issues/22)

## Details

Implementation of the `res.redirect` api, resolves #22 .

References:

* expressJsDocs: https://expressjs.com/en/4x/api.html#res.redirect

* expressJsCode: https://github.com/expressjs/express/blob/master/lib/response.js#L891

### Notable changes comparared to expressJs version

Raises exception if arguments provided are not valid.

## CheckList

- [x] PR starts with [#22].
- [x] Has been tested (where required) before merge to main.
