### PR TITLE
[#23] Array support for `res.append`

### DIFF
--- a/.github/API/response.md
+++ b/.github/API/response.md
@@ -53,12 +53,20 @@ app.use(function (req, res, next) {
 #### res.append(field [, value])
 
 Appends the specified `value` to the HTTP response header `field`. If the header is not already set, it creates the header with the specified string value.
+The value parameter can be a string or an array.
 
 Note: calling `res.set()` after `res.append()` will reset the previously-set header value.
 
 ```ts
 res.append("Set-Cookie", "foo=bar; Path=/; HttpOnly");
 res.append("Warning", "199 Miscellaneous warning");
+res.append(
+  "Link",
+  [
+    'https://www.google.com; rel="dns-prefetch"',
+    'https://www.youtube.com; rel="preconnect"',
+  ],
+);
 ```
 
 #### res.attachment([filename])

--- a/src/response.ts
+++ b/src/response.ts
@@ -36,22 +36,29 @@ export class Response implements DenoResponse {
   req!: Request;
   locals!: any;
 
-  // TODO: Supporting arrays.
   /**
    * Append additional header `field` with value `val`.
-   *
+   * Value can be either a `string` or an array of `string`.
+   * 
    * Example:
    *
    *    res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
    *    res.append('Warning', '199 Miscellaneous warning');
-   *
+   *    res.append("cache-control", ["public", "max-age=604800", "immutable"]);
+   * 
    * @param {string} field
-   * @param {string} value
+   * @param {string|string[]} value
    * @return {Response} for chaining
    * @public
    */
-  append(field: string, value: string): this {
-    this.headers.append(field, value);
+  append(field: string, value: string | string[]): this {
+    if (Array.isArray(value)) {
+      for (let i = 0, len = value.length; i < len; i++) {
+        this.headers.append(field, value[i]);
+      }
+    } else {
+      this.headers.append(field, value);
+    }
 
     return this;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -536,9 +536,15 @@ export interface Response<ResBody = any>
    * If the header is not already set, it creates the header with the specified value.
    * The value parameter can be a string or an array.
    *
+   * Example:
+   *
+   *    res.append('Set-Cookie', 'foo=bar; Path=/; HttpOnly');
+   *    res.append('Warning', '199 Miscellaneous warning');
+   *    res.append("cache-control", ["public", "max-age=604800", "immutable"]);
+   *
    * Note: calling res.set() after res.append() will reset the previously-set header value.
    */
-  append(field: string, value: string): this;
+  append(field: string, value: string | string[]): this;
 
   /**
    * Set _Content-Disposition_ header to _attachment_ with optional `filename`.


### PR DESCRIPTION
resolves #23 

Links:

* issue: https://github.com/asos-craigmorten/opine/issues/23

* expressJs docs: https://expressjs.com/en/4x/api.html#res.append

* expressJs code: https://github.com/expressjs/express/blob/master/lib/response.js#L722

# Issue

[#23](https://github.com/asos-craigmorten/opine/issues/23)

## Details

* modifies `res.append` signature from 

```typescript
field: string, value: string): this;
```

to 

```typescript
field: string, value: string|string[]): this;
```


## CheckList

- [x] PR starts with [#23].
- [x] Has been tested (where required) before merge to main.
