### PR TITLE
[ISSUE-58] Windows serveStatic file path handling fix

### DIFF
--- a/.github/API/response.md
+++ b/.github/API/response.md
@@ -180,6 +180,8 @@ try {
 }
 ```
 
+> **Note:** If providing a file URL to `res.download` as the `path` argument, path segments should first be URL encoded to ensure correct behaviour.
+
 #### async res.end([data])
 
 Ends the response process. This method actually just wraps the a method from the Deno standard http module, specifically the [respond() method of http.ServerRequest](https://doc.deno.land/https/deno.land/std/http/mod.ts#ServerRequest).
@@ -489,6 +491,8 @@ app.get("/user/:uid/photos/:file", function (req, res) {
   });
 });
 ```
+
+> **Note:** If providing a file URL to `res.sendFile` as the `path` argument, path segments should first be URL encoded to ensure correct behaviour.
 
 #### res.sendStatus(statusCode)
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,8 +7,7 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - name: Install wrk package
-        run: |
+      - run: |
           curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
           sudo apt-get update
           sudo apt-get install build-essential libssl-dev git -y
@@ -18,12 +17,10 @@ jobs:
           # move the executable to somewhere in your PATH, ex:
           sudo cp wrk /usr/local/bin
       - uses: actions/checkout@v2
-      - name: Use Deno ${{ matrix.deno-version }}
-        uses: denolib/setup-deno@v2
+      - uses: denolib/setup-deno@v2
         with:
           deno-version: 1.3.0
-      - name: Run Benchmark Tests
-        run: |
+      - run: |
           mkdir -p artifacts          
           cat > artifacts/message.md <<EOF
           # Benchmark results
@@ -36,8 +33,7 @@ jobs:
 
           </details>
           EOF
-      - name: Save PR message as artifact
-        uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v1
         with:
           name: pr_message
           path: artifacts

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -10,20 +10,16 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: Install deps
-        run: make deps
-      - name: Use Deno v1.3.0
-        uses: denolib/setup-deno@v2
+      - run: make deps
+      - uses: denolib/setup-deno@v2
         with:
           deno-version: 1.3.0
       - run: make typedoc
       - run: make ci
-      - name: Publish Updated Type Docs
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: publish typedocs
           push_options: --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,16 @@ on:
 
 jobs:
   build:
-    runs-on: [ubuntu-latest, windows-latest, macos-latest]
-
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         deno-version: [1.3.0]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Deno ${{ matrix.deno-version }}
-        uses: denolib/setup-deno@v2
+      - uses: denolib/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno-version }}
       - run: make ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest, macos-latest]
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         deno-version: [1.3.0]
 
     runs-on: ${{ matrix.os }}
@@ -21,3 +21,18 @@ jobs:
         with:
           deno-version: ${{ matrix.deno-version }}
       - run: make ci
+  test-win:
+    strategy:
+      matrix:
+        os: [windows-latest]
+        deno-version: [1.3.0]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: denolib/setup-deno@v2
+        with:
+          deno-version: ${{ matrix.deno-version }}
+      - run: make build
+      - run: make test

--- a/src/response.ts
+++ b/src/response.ts
@@ -536,6 +536,7 @@ export class Response implements DenoResponse {
    * @public
    */
   send(body: ResponseBody): this {
+    console.log("send()");
     let chunk: DenoResponseBody;
     let isUndefined = body === undefined;
 
@@ -575,6 +576,7 @@ export class Response implements DenoResponse {
         chunk instanceof Uint8Array) &&
       !isUndefined
     ) {
+      console.log("etag()");
       this.etag(chunk);
     }
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -12,6 +12,7 @@ import {
   vary,
   escapeHtml,
   encodeUrl,
+  fromFileUrl,
 } from "../deps.ts";
 import {
   Response as DenoResponse,
@@ -618,11 +619,7 @@ export class Response implements DenoResponse {
    * @public
    */
   async sendFile(path: string): Promise<this | void> {
-    /**
-     * Not ideal but fromFileUrl() seems to URL encode the basename if
-     * contains spaces / special characters!
-     */
-    path = path.startsWith("file:") ? path.replace("file:", "") : path;
+    path = path.startsWith("file:") ? fromFileUrl(path) : path;
 
     const stats: Deno.FileInfo = await Deno.stat(path);
 

--- a/src/response.ts
+++ b/src/response.ts
@@ -536,7 +536,6 @@ export class Response implements DenoResponse {
    * @public
    */
   send(body: ResponseBody): this {
-    console.log("send()");
     let chunk: DenoResponseBody;
     let isUndefined = body === undefined;
 
@@ -576,7 +575,6 @@ export class Response implements DenoResponse {
         chunk instanceof Uint8Array) &&
       !isUndefined
     ) {
-      console.log("etag()");
       this.etag(chunk);
     }
 

--- a/test/units/res.download.test.ts
+++ b/test/units/res.download.test.ts
@@ -47,11 +47,11 @@ describe("res", function () {
             return next(new Error("expected error"));
           }
 
-          res.send("got " + err.message);
+          res.send(err.message);
         }
       });
 
-      superdeno(app).get("/").expect(200, /No such file or directory/, done);
+      superdeno(app).get("/").expect(200, /(No such file or directory|The system cannot find the file specified)/, done);
     });
 
     it("should remove Content-Disposition", function (done) {

--- a/test/units/res.download.test.ts
+++ b/test/units/res.download.test.ts
@@ -51,7 +51,11 @@ describe("res", function () {
         }
       });
 
-      superdeno(app).get("/").expect(200, /(No such file or directory|The system cannot find the file specified)/, done);
+      superdeno(app).get("/").expect(
+        200,
+        /(No such file or directory|The system cannot find the file specified)/,
+        done,
+      );
     });
 
     it("should remove Content-Disposition", function (done) {

--- a/test/units/res.send.test.ts
+++ b/test/units/res.send.test.ts
@@ -533,10 +533,12 @@ describe("res", function () {
         const app = opine();
 
         app.set("etag", function (body: any) {
+          console.log("etag fn");
           return undefined;
         });
 
         app.use(function (req, res) {
+          console.log("middleware, sending...")
           res.send("hello, world!");
         });
 

--- a/test/units/res.send.test.ts
+++ b/test/units/res.send.test.ts
@@ -533,12 +533,10 @@ describe("res", function () {
         const app = opine();
 
         app.set("etag", function (body: any) {
-          console.log("etag fn");
           return undefined;
         });
 
         app.use(function (req, res) {
-          console.log("middleware, sending...")
           res.send("hello, world!");
         });
 

--- a/test/units/res.sendFile.test.ts
+++ b/test/units/res.sendFile.test.ts
@@ -34,7 +34,9 @@ describe("res", function () {
     it("should transfer a file with special characters in string (provided the path segment is passed through encodeURIComponent first)", function (
       done,
     ) {
-      const app = createApp(join(fixtures, encodeURIComponent("% of dogs.txt")));
+      const app = createApp(
+        join(fixtures, encodeURIComponent("% of dogs.txt")),
+      );
 
       superdeno(app)
         .get("/")

--- a/test/units/res.sendFile.test.ts
+++ b/test/units/res.sendFile.test.ts
@@ -7,13 +7,19 @@ import { Request, Response, NextFunction } from "../../src/types.ts";
 const __dirname = dirname(import.meta.url);
 const fixtures = join(__dirname, "../fixtures");
 
+console.log({ __dirname, fixtures });
+
 function createApp(path: string) {
+  console.log("createApp", { path });
   const app = opine();
 
   app.use(async function (req, res, next) {
     try {
+      console.log("createApp: sending file");
       await res.sendFile(path);
+      console.log("createApp: file sent");
     } catch (err) {
+      console.log("createApp: there was an error", { err });
       next(err);
     }
   });

--- a/test/units/res.sendFile.test.ts
+++ b/test/units/res.sendFile.test.ts
@@ -7,19 +7,13 @@ import { Request, Response, NextFunction } from "../../src/types.ts";
 const __dirname = dirname(import.meta.url);
 const fixtures = join(__dirname, "../fixtures");
 
-console.log({ __dirname, fixtures });
-
 function createApp(path: string) {
-  console.log("createApp", { path });
   const app = opine();
 
   app.use(async function (req, res, next) {
     try {
-      console.log("createApp: sending file");
       await res.sendFile(path);
-      console.log("createApp: file sent");
     } catch (err) {
-      console.log("createApp: there was an error", { err });
       next(err);
     }
   });
@@ -37,10 +31,10 @@ describe("res", function () {
         .expect(200, "deno", done);
     });
 
-    it("should transfer a file with special characters in string", function (
+    it("should transfer a file with special characters in string (provided the path segment is passed through encodeURIComponent first)", function (
       done,
     ) {
-      const app = createApp(join(fixtures, "% of dogs.txt"));
+      const app = createApp(join(fixtures, encodeURIComponent("% of dogs.txt")));
 
       superdeno(app)
         .get("/")


### PR DESCRIPTION
# Issue

[#58](https://github.com/asos-craigmorten/opine/issues/58)

## Details

Fix errors seen on windows when serving static files:

- use `fromFileUrl` so parse file URL properly
- update special character tests to first URL encode special characters - raised https://github.com/denoland/deno/issues/7094
- updated test error message expectation to handle windows variant

## CheckList

- [ ] PR starts with [#_ISSUE_ID_].
- [ ] Has been tested (where required) before merge to main.
