### PR TITLE
Fix heading in request API documentation

### DIFF
--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -119,7 +119,7 @@ app.post("/profile", function (req, res, next) {
 });
 ```
 
-#### req.fresh
+#### req.fresh
 
 When the response is still "fresh" in the client's cache `true` is returned, otherwise `false` is returned to indicate that the client cache is now stale and the full response should be sent.
 


### PR DESCRIPTION
Not sure why GitHub wouldn't render this as a heading. Seems from the diff there's some whitespace issue? 🤔 