### PR TITLE
[#26] Implement request body proxy

### DIFF
--- a/.github/API/middlewares.md
+++ b/.github/API/middlewares.md
@@ -8,9 +8,9 @@ This is a built-in middleware function in Opine. It parses incoming requests wit
 
 Returns middleware that only parses JSON and only looks at requests where the `Content-Type` header matches the `type` option. This parser accepts any Unicode encoding of the body and supports automatic inflation of `gzip` and `deflate` encodings.
 
-A new `parsedBody` object containing the parsed data is populated on the `request` object after the middleware (i.e. `req.parsedBody`), or an empty object (`{}`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. _Note:_ this is one way Opine differs from Express due to `req.body` being a protected property in Deno.
+After the middleware, the existing `body` property on the `request` object (i.e. `req.body`) is overwritten with the parsed data, or an empty object (`{}`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. The original, unparsed request `body` property is still available on the `raw` property (i.e. `req.raw`). A new `parsedBody` (i.e. `req.parsedBody`) object containing the parsed data is also available for backwards compatibility reasons.
 
-> As `req.parsedBody`'s shape is based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.parsedBody.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
+> As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
 import { opine, json } from "https://deno.land/x/opine@0.28.0/mod.ts";
@@ -20,8 +20,8 @@ const app = opine();
 app.use(json()); // for parsing application/json
 
 app.post("/profile", function (req, res, next) {
-  console.log(req.parsedBody);
-  res.json(req.parsedBody);
+  console.log(req.body);
+  res.json(req.body);
 });
 ```
 
@@ -42,9 +42,9 @@ This is a built-in middleware function in Opine. It parses incoming request payl
 
 Returns middleware that parses all bodies as a `Buffer` and only looks at requests where the `Content-Type` header matches the `type` option. This parser accepts any Unicode encoding of the body and supports automatic inflation of `gzip` and `deflate` encodings.
 
-A new `parsedBody` `Buffer` containing the parsed data is populated on the `request` object after the middleware (i.e. `req.parsedBody`), or an empty string (`""`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. _Note:_ this is one way Opine differs from Express due to `req.body` being a protected property in Deno.
+After the middleware, the existing `body` property on the `request` object (i.e. `req.body`) is overwritten with the parsed data, or an empty string (`""`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. The original, unparsed request `body` property is still available on the `raw` property (i.e. `req.raw`). A new `parsedBody` (i.e. `req.parsedBody`) string containing the parsed data is also available for backwards compatibility reasons.
 
-> As `req.parsedBody`'s shape is based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.parsedBody.toString()` may fail in multiple ways, for example stacking multiple parsers `req.parsedBody` may be from a different parser. Testing that `req.parsedBody` is a `Buffer` before calling buffer methods is recommended.
+> As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.toString()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.body` is a string before calling string methods is recommended.
 
 ```ts
 import { opine, raw } from "https://deno.land/x/opine@0.28.0/mod.ts";
@@ -54,8 +54,8 @@ const app = opine();
 app.use(raw()); // for parsing application/octet-stream
 
 app.post("/upload", function (req, res, next) {
-  console.log(req.parsedBody);
-  res.json(req.parsedBody);
+  console.log(req.body);
+  res.json(req.body);
 });
 ```
 
@@ -161,9 +161,9 @@ This is a built-in middleware function in Opine. It parses incoming request payl
 
 Returns middleware that parses all bodies as a string and only looks at requests where the `Content-Type` header matches the `type` option. This parser accepts any Unicode encoding of the body and supports automatic inflation of `gzip` and `deflate` encodings.
 
-A new `parsedBody` string containing the parsed data is populated on the `request` object after the middleware (i.e. `req.parsedBody`), or an empty string (`""`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. _Note:_ this is one way Opine differs from Express due to `req.body` being a protected property in Deno.
+After the middleware, the existing `body` property on the `request` object (i.e. `req.body`) is overwritten with the parsed data, or an empty string (`""`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. The original, unparsed request `body` property is still available on the `raw` property (i.e. `req.raw`). A new `parsedBody` (i.e. `req.parsedBody`) string containing the parsed data is also available for backwards compatibility reasons.
 
-> As `req.parsedBody`'s shape is based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.parsedBody.trim()` may fail in multiple ways, for example stacking multiple parsers `req.parsedBody` may be from a different parser. Testing that `req.parsedBody` is a string before calling string methods is recommended.
+> As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.trim()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.parsedBody` is a string before calling string methods is recommended.
 
 ```ts
 import { opine, text } from "https://deno.land/x/opine@0.28.0/mod.ts";
@@ -173,8 +173,8 @@ const app = opine();
 app.use(text()); // for parsing text/plain
 
 app.post("/logs", function (req, res, next) {
-  console.log(req.parsedBody);
-  res.json(req.parsedBody);
+  console.log(req.body);
+  res.json(req.body);
 });
 ```
 
@@ -193,9 +193,9 @@ This is a built-in middleware function in Opine. It parses incoming requests wit
 
 Returns middleware that only parses urlencoded bodies and only looks at requests where the `Content-Type` header matches the `type` option. This parser accepts only UTF-8 encoding of the body and supports automatic inflation of `gzip` and `deflate` encodings.
 
-A new `parsedBody` object containing the parsed data is populated on the `request` object after the middleware (i.e. `req.parsedBody`), or an empty object (`{}`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. This object will contain key-value pairs, where the value can be any type supported by the URLSearchParams API. _Note:_ this is one way Opine differs from Express due to `req.body` being a protected property in Deno.
+After the middleware, the existing `body` property on the `request` object (i.e. `req.body`) is overwritten with the parsed data, or an empty object (`{}`) if there was no body to parse, the `Content-Type` was not matched, or an error occurred. The original, unparsed request `body` property is still available on the `raw` property (i.e. `req.raw`). A new `parsedBody` (i.e. `req.parsedBody`) object containing the parsed data is also available for backwards compatibility reasons.
 
-> As `req.parsedBody`'s shape is based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.parsedBody.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
+> As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
 import { opine, urlencoded } from "https://deno.land/x/opine@0.28.0/mod.ts";
@@ -205,8 +205,8 @@ const app = opine();
 app.use(urlencoded()); // for parsing application/x-www-form-urlencoded
 
 app.post("/submit", function (req, res, next) {
-  console.log(req.parsedBody);
-  res.json(req.parsedBody);
+  console.log(req.body);
+  res.json(req.body);
 });
 ```
 

--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -77,7 +77,7 @@ When a request is made to `/greet/jp`, `req.baseUrl` is "/greet". When a request
 
 Contains the data submitted in the request body. By default the `req.body` is a `Deno.Reader`, and needs to be read using a body-parsing middleware such as [`json()`](./bodyParser.md) or [`urlencoded()`](./bodyParser.md).
 
-The following example shows how to use body-parsing middleware to populate `req.parsedBody`. _Note:_ this is one way Opine differs from Express due to `req.body` being a protected property in Deno.
+The following example shows how to use body-parsing middleware to populate `req.body`.
 
 ```ts
 import {
@@ -92,12 +92,12 @@ app.use(json()); // for parsing application/json
 app.use(urlencoded()); // for parsing application/x-www-form-urlencoded
 
 app.post("/profile", function (req, res, next) {
-  console.log(req.parsedBody);
-  res.json(req.parsedBody);
+  console.log(req.body);
+  res.json(req.body);
 });
 ```
 
-The following example shows how to implement your own simple body-parsing middleware to transform `req.parsedBody` into a raw string:
+The following example shows how to implement your own simple body-parsing middleware to transform `req.body` into a raw string:
 
 ```ts
 import opine from "https://deno.land/x/opine@0.28.0/mod.ts";
@@ -105,17 +105,17 @@ import opine from "https://deno.land/x/opine@0.28.0/mod.ts";
 const app = opine();
 
 const bodyParser = async function (req, res, next) {
-  const rawBody = await Deno.readAll(req.body);
+  const rawBody = await Deno.readAll(req.raw);
   const decodedBody = decoder.decode(rawBody);
 
-  (req as any).parsedBody = decodedBody;
+  req.body = decodedBody;
 };
 
 app.use(bodyParser);
 
 app.post("/profile", function (req, res, next) {
-  console.log(req.parsedBody);
-  res.send(req.parsedBody);
+  console.log(req.body);
+  res.send(req.body);
 });
 ```
 
@@ -262,7 +262,11 @@ console.dir(req.query.color);
 // => ['blue', 'black', 'red']
 ```
 
-#### req.route
+#### req.raw
+
+Contains the data submitted in the request body. The `req.raw` is a `Deno.Reader`, and needs to be read using a body-parsing middleware such as [`json()`](./bodyParser.md) or [`urlencoded()`](./bodyParser.md). Unlike the `req.body` property, `req.raw` cannot be overwritten and will always return the original request body.
+
+#### req.route
 
 Contains the currently-matched route, a string. For example:
 
@@ -360,7 +364,7 @@ req.accepts(["html", "json"]);
 // => "json"
 ```
 
-#### req.acceptsCharsets(charset [, ...])
+#### req.acceptsCharsets(charset [, ...])
 
 Returns the first accepted charset of the specified character sets, based on the request's `Accept-Charset` HTTP header field. If none of the specified charsets is accepted, returns empty.
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -135,7 +135,7 @@
 - fix: proxy example.
 - [#20] Add instructions for nest.land package registry (#35).
 
-## [0.14.0] - 29-06-2020
+## [0.14.0] - 29-06-2020
 
 - fix: several minor bugfixes.
 - test: add serious test coverage.

--- a/examples/json/index.ts
+++ b/examples/json/index.ts
@@ -16,13 +16,14 @@ import { json, opine } from "../../mod.ts";
 const app = opine();
 
 // Use the JSON body parser to set `req.parsedBody` to the
-// passed JSON payload.
+// passed JSON payload. Opine also exposes this value on
+// the `req.body` property itself for convenience.
 app.use(json());
 
 // Receive `POST` requests to `/` and return the passed
 // JSON body.
 app.post("/", function (req, res) {
-  res.send(req.parsedBody);
+  res.send(req.body);
 });
 
 // You can call listen the same as Express with just

--- a/examples/mvc/controllers/pet/index.ts
+++ b/examples/mvc/controllers/pet/index.ts
@@ -33,7 +33,7 @@ export const update = function (
   res: Response,
   _next: NextFunction,
 ) {
-  const body = req.parsedBody;
+  const body = req.body;
   (req as any).pet.name = body.pet.name;
   res.redirect(`/pet/${(req as any).pet.id}`);
 };

--- a/examples/mvc/controllers/user-pet/index.ts
+++ b/examples/mvc/controllers/user-pet/index.ts
@@ -11,7 +11,7 @@ export const create = function (
 ) {
   const id = req.params.user_id;
   const user = db.users[parseInt(id)];
-  const body = req.parsedBody;
+  const body = req.body;
   if (!user) return next("route");
   const pet: any = { name: body.pet.name };
   pet.id = db.pets.push(pet) - 1;

--- a/examples/mvc/controllers/user/index.ts
+++ b/examples/mvc/controllers/user/index.ts
@@ -47,7 +47,7 @@ export const update = function (
   res: Response,
   _next: NextFunction,
 ) {
-  const body = req.parsedBody;
+  const body = req.body;
   (req as any).user.name = body.user.name;
   res.redirect("/user/" + (req as any).user.id);
 };

--- a/examples/raw/index.ts
+++ b/examples/raw/index.ts
@@ -16,13 +16,14 @@ import { opine, raw } from "../../mod.ts";
 const app = opine();
 
 // Use the raw body parser to set `req.parsedBody` to a
-// decoded raw body.
+// decoded raw body. Opine also exposes this value on
+// the `req.body` property itself for convenience.
 app.use(raw());
 
 // Receive `POST` requests to `/` and return the decoded
 // raw body.
 app.post("/", function (req, res) {
-  res.send(req.parsedBody);
+  res.send(req.body);
 });
 
 // You can call listen the same as Express with just

--- a/examples/text/index.ts
+++ b/examples/text/index.ts
@@ -16,13 +16,14 @@ import { opine, text } from "../../mod.ts";
 const app = opine();
 
 // Use the text body parser to set `req.parsedBody` to a
-// decoded text body.
+// decoded text body. Opine also exposes this value on
+// the `req.body` property itself for convenience.
 app.use(text());
 
 // Receive `POST` requests to `/` and return the decoded
 // text body.
 app.post("/", function (req, res) {
-  res.send(req.parsedBody);
+  res.send(req.body);
 });
 
 // You can call listen the same as Express with just

--- a/examples/urlencoded/index.ts
+++ b/examples/urlencoded/index.ts
@@ -16,13 +16,14 @@ import { opine, urlencoded } from "../../mod.ts";
 const app = opine();
 
 // Use the urlencoded body parser to set `req.parsedBody` to a
-// decoded version of the passed payload.
+// decoded version of the passed payload. Opine also exposes
+// this value on the `req.body` property itself for convenience.
 app.use(urlencoded());
 
 // Receive `POST` requests to `/` and return the decoded
 // version of the passed urlencoded body.
 app.post("/", function (req, res) {
-  res.send(req.parsedBody);
+  res.send(req.body);
 });
 
 // You can call listen the same as Express with just

--- a/src/application.ts
+++ b/src/application.ts
@@ -11,6 +11,7 @@ import { methods } from "./methods.ts";
 import { Router } from "./router/index.ts";
 import { init } from "./middleware/init.ts";
 import { query } from "./middleware/query.ts";
+import { requestProxy } from "./utils/requestProxy.ts";
 import { finalHandler } from "./utils/finalHandler.ts";
 import { compileETag } from "./utils/compileETag.ts";
 import { compileQueryParser } from "./utils/compileQueryParser.ts";
@@ -146,6 +147,8 @@ app.handle = function handle(
   next: NextFunction,
 ): void {
   const router = this._router;
+
+  req = requestProxy(req);
 
   next = next || finalHandler(req, res);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -518,8 +518,20 @@ export interface Request<
 
   /**
    * Body of request.
+   * 
+   * If the body has been passed such that a `parsedBody`
+   * property is defined, this returns the `parsedBody`
+   * value.
+   * 
+   * To always get the raw body value, use the `raw`
+   * property.
    */
-  body: Deno.Reader;
+  body: any;
+
+  /**
+   * Raw body of request.
+   */
+  raw: Deno.Reader;
 
   method: string;
 
@@ -551,7 +563,7 @@ export interface Request<
   next?: NextFunction;
 
   /**
-   * After body parsers, Request will contain _parsedBody boolean property
+   * After body parsers, Request will contain `_parsedBody` boolean property
    * dictating that the body has been parsed.
    * See: opine/src/middleware/bodyParser/
    */

--- a/src/utils/requestProxy.ts
+++ b/src/utils/requestProxy.ts
@@ -1,0 +1,23 @@
+import { Request } from "../types.ts";
+
+export const requestProxy = (req: Request): Request =>
+  new Proxy(req, {
+    get: (target: any, name: string | number | symbol) => {
+      if (name === "body") {
+        return target.parsedBody ?? target.body;
+      } else if (name === "raw") {
+        return target.body;
+      }
+
+      return target[name];
+    },
+    set: (target: any, name: string | number | symbol, value: any): boolean => {
+      if (name === "body") {
+        target.parsedBody = value;
+      } else {
+        target[name] = value;
+      }
+
+      return true;
+    },
+  });


### PR DESCRIPTION
# Issue

Fixes #26.

## Details

Implements a proxy to allow users to overwrite the `req.body` property (e.g. via body parsers) rather than have to reference a new `parsedBody` property.

To allow access to the original body, a `req.raw` property has been implemented.

The `req.parsedBody` has been left in place for backward compatibility reasons.

This is a breaking change as it changes the characteristics of the `req.body` property, which is fairly central to Opine and general request / server usage and patterns.

Hat tip to @DxSimonovski and their contribution https://github.com/asos-craigmorten/opine/pull/86. Too impatient to get this in so cherry picked bits and pieces to get it across the line! 😅

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to main.
