### PR TITLE
[#96] Replace `denoflate` library with `compress` library

### DIFF
--- a/.github/API/application.md
+++ b/.github/API/application.md
@@ -7,7 +7,7 @@ Adapted from the [ExpressJS API Docs](https://expressjs.com/en/4x/api.html).
 The `app` object conventionally denotes the Opine application. Create it by calling the top-level `opine()` function exported by the Opine module:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -59,7 +59,7 @@ The `app.mountpath` property contains one or more path patterns on which a sub-a
 > A sub-app is an instance of `opine` that may be used for handling the request to a route.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine(); // the main app
 const admin = opine(); // the sub app
@@ -447,7 +447,7 @@ app.get("/", function (req, res) {
 Binds and listens for connections on the specified address. This method is nearly identical to Deno's [http.listenAndServe()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServe). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -477,7 +477,7 @@ Binds and listens for connections on the specified numerical port. If no port is
 This method is supported for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 const PORT = 3000;
@@ -490,7 +490,7 @@ app.listen(PORT, () => console.log(`Server started on port ${PORT}`));
 Binds and listens for connections using the specified [http.HTTPOptions](https://doc.deno.land/https/deno.land/std/http/server.ts#HTTPOptions). This method is nearly identical to Deno's [http.listenAndServe()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServe). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -502,7 +502,7 @@ app.listen({ port: 3000 });
 Binds and listens for connections using the specified [http.HTTPSOptions](https://doc.deno.land/https/deno.land/std/http/server.ts#HTTPSOptions). This method is nearly identical to Deno's [http.listenAndServeTLS()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServeTLS). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 

--- a/.github/API/middlewares.md
+++ b/.github/API/middlewares.md
@@ -13,7 +13,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
-import { opine, json } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine, json } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -47,7 +47,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.toString()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.body` is a string before calling string methods is recommended.
 
 ```ts
-import { opine, raw } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine, raw } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -166,7 +166,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.trim()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.parsedBody` is a string before calling string methods is recommended.
 
 ```ts
-import { opine, text } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine, text } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -198,7 +198,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
-import { opine, urlencoded } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine, urlencoded } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 

--- a/.github/API/opine.md
+++ b/.github/API/opine.md
@@ -7,7 +7,7 @@ Adapted from the [ExpressJS API Docs](https://expressjs.com/en/4x/api.html).
 Creates an Opine application. The `opine()` function is a top-level function exported by the Opine module:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 ```
@@ -15,7 +15,7 @@ const app = opine();
 The `opine()` function is also exported as a named export:
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 ```

--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -84,7 +84,7 @@ import {
   opine,
   json,
   urlencoded,
-} from "https://deno.land/x/opine@1.0.2/mod.ts";
+} from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -100,7 +100,7 @@ app.post("/profile", function (req, res, next) {
 The following example shows how to implement your own simple body-parsing middleware to transform `req.body` into a raw string:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 

--- a/.github/API/router.md
+++ b/.github/API/router.md
@@ -11,7 +11,7 @@ A router behaves like middleware itself, so you can use it as an argument to [ap
 Opine has a top-level named function export `Router()` that creates a new `router` object.
 
 ```ts
-import { Router } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { Router } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const router = Router(options);
 ```
@@ -210,7 +210,7 @@ This method is similar to [app.use()](./application#appusepath-callback--callbac
 Middleware is like a plumbing pipe: requests start at the first middleware function defined and work their way "down" the middleware stack processing for each path they match.
 
 ```ts
-import opine, { Router } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import opine, { Router } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 const router = Router();

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## [1.1.0] - 17-01-2021
+
+- refactor: replace `denoflate` library with `compress` library to remove net requirement as a result of wasm usage.
+- chore: upgrade to official denoland vscode plugin.
+
 ## [1.0.2] - 02-01-2021
 
 - feat: Support Deno `1.6.3` and std `0.83.0`

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,13 @@
   "deno.enable": true,
   "deno.unstable": true,
   "[typescript]": {
-    "editor.defaultFormatter": "axetroy.vscode-deno"
+    "editor.defaultFormatter": "denoland.vscode-deno"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "axetroy.vscode-deno"
+    "editor.defaultFormatter": "denoland.vscode-deno"
   },
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "deno.import_intellisense_origins": {
+    "https://deno.land": true
+  }
 }

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Fast, minimalist web framework for <a href="https://deno.land/">Deno</a> ported 
 ## Getting Started
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.1.0/mod.ts";
 
 const app = opine();
 
@@ -55,13 +55,13 @@ Before importing, [download and install Deno](https://deno.land/#installation).
 You can then import Opine straight into your project:
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.0.2/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.1.0/mod.ts";
 ```
 
 Opine is also available on [nest.land](https://nest.land/package/opine), a package registry for Deno on the Blockchain.
 
 ```ts
-import { opine } from "https://x.nest.land/opine@1.0.2/mod.ts";
+import { opine } from "https://x.nest.land/opine@1.1.0/mod.ts";
 ```
 
 ## Features
@@ -92,7 +92,7 @@ The quickest way to get started with Opine is to utilize the [Opine CLI](https:/
 Install the executable. The executable's major version will match Opine's:
 
 ```bash
-deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.0.2/opine-cli.ts
+deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.1.0/opine-cli.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/deps.ts
+++ b/deps.ts
@@ -52,7 +52,7 @@ export { isIP } from "https://deno.land/x/isIP@1.0.0/mod.ts";
 export { vary } from "https://deno.land/x/vary@1.0.0/mod.ts";
 export { escapeHtml } from "https://deno.land/x/escape_html@1.0.0/mod.ts";
 export { encodeUrl } from "https://deno.land/x/encodeurl@1.0.0/mod.ts";
-export { gunzip, inflate } from "https://deno.land/x/denoflate@1.1/mod.ts";
+export { gunzip, inflate } from "https://deno.land/x/compress@v0.3.6/mod.ts";
 export { default as parseRange } from "https://esm.sh/range-parser@1.2.1";
 export { default as qs } from "https://esm.sh/qs@6.9.4";
 export { default as ipaddr } from "https://esm.sh/ipaddr.js@2.0.0";

--- a/docs/index.html
+++ b/docs/index.html
@@ -99,7 +99,7 @@
 				<a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
 					<h2>Getting Started</h2>
 				</a>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.0.2/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.1.0/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
 
@@ -114,9 +114,9 @@ app.listen(<span class="hljs-number">3000</span>);</code></pre>
 				<p>This is a <a href="https://deno.land/">Deno</a> module available to import direct from this repo and via the <a href="https://deno.land/x">Deno Registry</a>.</p>
 				<p>Before importing, <a href="https://deno.land/#installation">download and install Deno</a>.</p>
 				<p>You can then import Opine straight into your project:</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.0.2/mod.ts&quot;</span>;</code></pre>
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.1.0/mod.ts&quot;</span>;</code></pre>
 				<p>Opine is also available on <a href="https://nest.land/package/opine">nest.land</a>, a package registry for Deno on the Blockchain.</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/opine@1.0.2/mod.ts&quot;</span>;</code></pre>
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/opine@1.1.0/mod.ts&quot;</span>;</code></pre>
 				<a href="#features" id="features" style="color: inherit; text-decoration: none;">
 					<h2>Features</h2>
 				</a>
@@ -147,7 +147,7 @@ app.listen(<span class="hljs-number">3000</span>);</code></pre>
 				</a>
 				<p>The quickest way to get started with Opine is to utilize the <a href="https://github.com/cmorten/opine-cli">Opine CLI</a> to generate an application as shown below:</p>
 				<p>Install the executable. The executable&#39;s major version will match Opine&#39;s:</p>
-				<pre><code class="language-bash">deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.0.2/opine-cli.ts</code></pre>
+				<pre><code class="language-bash">deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.1.0/opine-cli.ts</code></pre>
 				<p>And follow any suggestions to update your <code>PATH</code> environment variable.</p>
 				<p>Create the app:</p>
 				<pre><code class="language-bash">opine-cli --view=ejs hello-deno &amp;&amp; <span class="hljs-built_in">cd</span> hello-deno</code></pre>

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "opine",
     "description": "Fast, minimalist web framework for Deno ported from ExpressJS.",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "repository": "https://github.com/asos-craigmorten/opine",
     "stable": true,
     "files": [

--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 /**
  * Version of Opine.
  */
-export const VERSION: string = "1.0.2";
+export const VERSION: string = "1.1.0";
 
 /**
  * Supported version of Deno.


### PR DESCRIPTION
# Issue

Fixes #96 

## Details

- refactor: replace `denoflate` library with `compress` library to remove net requirement as a result of wasm usage.
- chore: upgrade to official denoland vscode plugin.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to main.
