### PR TITLE
[#105] Updates react example for deno 1.7.5

### DIFF
--- a/examples/react/server.tsx
+++ b/examples/react/server.tsx
@@ -1,17 +1,16 @@
 /**
  * Run this example using:
- * 
+ *
  *    deno run --allow-net --allow-read --unstable ./examples/react/server.tsx
- * 
+ *
  * if have the repo cloned locally. Unfortunately template rendering does not
  * currently support remote URLs for views, so this example cannot be run directly
  * from this repo.
- * 
+ *
  */
-
-import { opine, serveStatic } from "../../mod.ts";
-import { dirname, join } from "../../deps.ts";
-import { renderFileToString } from "https://deno.land/x/dejs@0.8.0/mod.ts";
+import { opine, serveStatic } from "https://deno.land/x/opine@1.1.0/mod.ts";
+import { dirname, join } from "https://deno.land/x/opine@1.1.0/deps.ts";
+import { renderFileToString } from "https://deno.land/x/dejs@0.9.3/mod.ts";
 // @deno-types="https://raw.githubusercontent.com/Soremwar/deno_types/4a50660/react/v16.13.1/react.d.ts"
 import React from "https://dev.jspm.io/react@16.13.1";
 import ReactDOMServer from "https://dev.jspm.io/react-dom@16.13.1/server";
@@ -21,10 +20,14 @@ import { App } from "./components/App.tsx";
  * Create our client bundle - you could split this out into
  * a preprocessing step.
  */
-const [diagnostics, js] = await Deno.bundle(
+const { diagnostics, files } = await Deno.emit(
   "./examples/react/client.tsx",
-  undefined,
-  { lib: ["dom", "dom.iterable", "esnext"] },
+  {
+    bundle: "esm",
+    compilerOptions: {
+      lib: ["dom", "dom.iterable", "esnext"],
+    },
+  },
 );
 
 if (diagnostics) {
@@ -71,6 +74,7 @@ app.use("/api/v1/doggos", (req, res) => {
  * Serve our client JS bundle.
  */
 app.get("/scripts/client.js", async (req, res) => {
+  const js = files["deno:///bundle.js"];
   res.type("application/javascript").send(js);
 });
 


### PR DESCRIPTION
# Issue

Fixes #105 

## Details

Makes some updates to react example, so it will run for deno 1.7.5

- Updates dejs `v0.8.0` to `v0.9.3`
- Moves from deprecated `Deno.bundle` to `Deno.emit`
- Uses full dep urls, rather than local urls, for clarity of import intention (as an example app)

## CheckList

- [x] PR starts with [#105].
- [x] Has been tested (where required).
^ Looks like there's no testing required for this file, so I just ran `deno fmt` on the `server.tsx` file and called it a day.
