### PR TITLE
Add GraphQL example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,8 +18,8 @@ applications:
   and rendering capabilities for custom error pages.
 - [eta](./eta) - Example of how to use Opine's template engine and rendering
   capabilities with the `eta` template engine.
-- [graphql](./graphql) - Example of how to use Opine with [gql](https://github.com/deno-libs/gql) for a
-simple GraphQL server.
+- [graphql](./graphql) - Example of how to use Opine with
+  [gql](https://github.com/deno-libs/gql) for a simple GraphQL server.
 - [hello-world](./hello-world) - A basic example of how to configure and start
   an Opine server.
 - [json](./json) - An example of how to use the `json` body-parser middleware in

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,8 @@ applications:
   and rendering capabilities for custom error pages.
 - [eta](./eta) - Example of how to use Opine's template engine and rendering
   capabilities with the `eta` template engine.
+- [graphql](./graphql) - Example of how to use Opine with [gql](https://github.com/deno-libs/gql) for a
+simple GraphQL server.
 - [hello-world](./hello-world) - A basic example of how to configure and start
   an Opine server.
 - [json](./json) - An example of how to use the `json` body-parser middleware in

--- a/examples/graphql/README.md
+++ b/examples/graphql/README.md
@@ -1,6 +1,7 @@
 # graphql
 
-Example of how to use Opine with [gql](https://github.com/deno-libs/gql) for a simple GraphQL server.
+Example of how to use Opine with [gql](https://github.com/deno-libs/gql) for a
+simple GraphQL server.
 
 ## How to run this example
 

--- a/examples/graphql/README.md
+++ b/examples/graphql/README.md
@@ -1,0 +1,38 @@
+# graphql
+
+Example of how to use Opine with [gql](https://github.com/deno-libs/gql) for a simple GraphQL server.
+
+## How to run this example
+
+```sh
+deno run --allow-net --allow-read ./examples/grapqhl/index.ts
+```
+
+if have the repo cloned locally OR
+
+```sh
+deno run --allow-net --allow-read https://raw.githubusercontent.com/asos-craigmorten/opine/main/examples/graphql/index.ts
+```
+
+if you don't!
+
+Then try:
+
+1. Opening a GraphQL playground on http//localhost:3000/graphql
+2. Writing a query:
+
+```graphql
+{
+  hello
+}
+```
+
+3. You will get this:
+
+```
+{
+  "data": {
+    "hello": "Hello World!"
+  }
+}
+```

--- a/examples/graphql/index.ts
+++ b/examples/graphql/index.ts
@@ -1,0 +1,39 @@
+/**
+ * Run this example using:
+ *
+ *    deno run --allow-net --allow-read ./examples/graphql/index.ts
+ *
+ *    if have the repo cloned locally OR
+ *
+ *    deno run --allow-net --allow-read https://raw.githubusercontent.com/asos-craigmorten/opine/main/examples/graphql/index.ts
+ *
+ *    if you don't!
+ *
+ */
+
+import { opine } from "../../mod.ts";
+import { GraphQLHTTP } from "https://deno.land/x/gql@0.1.1/mod.ts";
+import { makeExecutableSchema } from "https://deno.land/x/graphql_tools@0.0.0/mod.ts";
+import { gql } from "https://deno.land/x/graphql_tag@0.0.0/mod.ts";
+
+const typeDefs = gql`
+  type Query {
+    hello: String
+  }
+`;
+
+const resolvers = {
+  Query: {
+    hello: () => `Hello World!`,
+  },
+};
+
+const schema = makeExecutableSchema({ resolvers, typeDefs });
+
+const app = opine();
+
+app.use("/graphql", GraphQLHTTP({ schema, graphiql: true }));
+
+app.listen(3000);
+
+console.log("Opine started on port 3000");


### PR DESCRIPTION
## Details

This PR adds a GraphQL server example with Opine and [gql](https://github.com/deno-libs/gql), a GraphQL HTTP middleware.

## Checklist

- [x] `deno fmt`
- [x] README 
