### PR TITLE
[NO-ISSUE] Downgrade eggs publish to Deno `1.8.3` due to bug in Eggs CLI

### DIFF
--- a/.github/API/application.md
+++ b/.github/API/application.md
@@ -7,7 +7,7 @@ Adapted from the [ExpressJS API Docs](https://expressjs.com/en/4x/api.html).
 The `app` object conventionally denotes the Opine application. Create it by calling the top-level `opine()` function exported by the Opine module:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -59,7 +59,7 @@ The `app.mountpath` property contains one or more path patterns on which a sub-a
 > A sub-app is an instance of `opine` that may be used for handling the request to a route.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine(); // the main app
 const admin = opine(); // the sub app
@@ -447,7 +447,7 @@ app.get("/", function (req, res) {
 Binds and listens for connections on the specified address. This method is nearly identical to Deno's [http.listenAndServe()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServe). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -477,7 +477,7 @@ Binds and listens for connections on the specified numerical port. If no port is
 This method is supported for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 const PORT = 3000;
@@ -490,7 +490,7 @@ app.listen(PORT, () => console.log(`Server started on port ${PORT}`));
 Binds and listens for connections using the specified [http.HTTPOptions](https://doc.deno.land/https/deno.land/std/http/server.ts#HTTPOptions). This method is nearly identical to Deno's [http.listenAndServe()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServe). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -502,7 +502,7 @@ app.listen({ port: 3000 });
 Binds and listens for connections using the specified [http.HTTPSOptions](https://doc.deno.land/https/deno.land/std/http/server.ts#HTTPSOptions). This method is nearly identical to Deno's [http.listenAndServeTLS()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServeTLS). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 

--- a/.github/API/middlewares.md
+++ b/.github/API/middlewares.md
@@ -13,7 +13,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
-import { opine, json } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine, json } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -47,7 +47,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.toString()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.body` is a string before calling string methods is recommended.
 
 ```ts
-import { opine, raw } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine, raw } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -166,7 +166,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.trim()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.parsedBody` is a string before calling string methods is recommended.
 
 ```ts
-import { opine, text } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine, text } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -198,7 +198,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
-import { opine, urlencoded } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine, urlencoded } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 

--- a/.github/API/opine.md
+++ b/.github/API/opine.md
@@ -7,7 +7,7 @@ Adapted from the [ExpressJS API Docs](https://expressjs.com/en/4x/api.html).
 Creates an Opine application. The `opine()` function is a top-level function exported by the Opine module:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 ```
@@ -15,7 +15,7 @@ const app = opine();
 The `opine()` function is also exported as a named export:
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 ```

--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -84,7 +84,7 @@ import {
   opine,
   json,
   urlencoded,
-} from "https://deno.land/x/opine@1.3.0/mod.ts";
+} from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -100,7 +100,7 @@ app.post("/profile", function (req, res, next) {
 The following example shows how to implement your own simple body-parsing middleware to transform `req.body` into a raw string:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 

--- a/.github/API/router.md
+++ b/.github/API/router.md
@@ -11,7 +11,7 @@ A router behaves like middleware itself, so you can use it as an argument to [ap
 Opine has a top-level named function export `Router()` that creates a new `router` object.
 
 ```ts
-import { Router } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { Router } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const router = Router(options);
 ```
@@ -210,7 +210,7 @@ This method is similar to [app.use()](./application#appusepath-callback--callbac
 Middleware is like a plumbing pipe: requests start at the first middleware function defined and work their way "down" the middleware stack processing for each path they match.
 
 ```ts
-import opine, { Router } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import opine, { Router } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 const router = Router();

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## [1.3.1] - 14-04-2021
+
+- ci: downgrade eggs publish to Deno `1.8.3` due to bug in Eggs CLI.
+
 ## [1.3.0] - 14-04-2021
 
 - feat: support Deno `1.9.0` and std `0.93.0`

--- a/.github/workflows/publish-egg.yml
+++ b/.github/workflows/publish-egg.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.9.0
-      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.4/eggs.ts
+          deno-version: 1.8.3
+      - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.5/eggs.ts
       - run: |
           export PATH="/home/runner/.deno/bin:$PATH"
           eggs link ${NEST_LAND_KEY}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Fast, minimalist web framework for <a href="https://deno.land/">Deno</a> ported 
 ## Getting Started
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.3.1/mod.ts";
 
 const app = opine();
 
@@ -62,13 +62,13 @@ Before importing, [download and install Deno](https://deno.land/#installation).
 You can then import Opine straight into your project:
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.3.0/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.3.1/mod.ts";
 ```
 
 Opine is also available on [nest.land](https://nest.land/package/opine), a package registry for Deno on the Blockchain.
 
 ```ts
-import { opine } from "https://x.nest.land/opine@1.3.0/mod.ts";
+import { opine } from "https://x.nest.land/opine@1.3.1/mod.ts";
 ```
 
 ## Features
@@ -99,7 +99,7 @@ The quickest way to get started with Opine is to utilize the [Opine CLI](https:/
 Install the executable. The executable's major version will match Opine's:
 
 ```bash
-deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.3.0/opine-cli.ts
+deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.3.1/opine-cli.ts
 ```
 
 And follow any suggestions to update your `PATH` environment variable.

--- a/docs/index.html
+++ b/docs/index.html
@@ -106,7 +106,7 @@
 				<a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
 					<h2>Getting Started</h2>
 				</a>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.3.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.3.1/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
 
@@ -122,10 +122,10 @@ app.listen(<span class="hljs-number">3000</span>);
 				<p>This is a <a href="https://deno.land/">Deno</a> module available to import direct from this repo and via the <a href="https://deno.land/x">Deno Registry</a>.</p>
 				<p>Before importing, <a href="https://deno.land/#installation">download and install Deno</a>.</p>
 				<p>You can then import Opine straight into your project:</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.3.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.3.1/mod.ts&quot;</span>;
 </code></pre>
 				<p>Opine is also available on <a href="https://nest.land/package/opine">nest.land</a>, a package registry for Deno on the Blockchain.</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/opine@1.3.0/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/opine@1.3.1/mod.ts&quot;</span>;
 </code></pre>
 				<a href="#features" id="features" style="color: inherit; text-decoration: none;">
 					<h2>Features</h2>
@@ -157,7 +157,7 @@ app.listen(<span class="hljs-number">3000</span>);
 				</a>
 				<p>The quickest way to get started with Opine is to utilize the <a href="https://github.com/cmorten/opine-cli">Opine CLI</a> to generate an application as shown below:</p>
 				<p>Install the executable. The executable&#39;s major version will match Opine&#39;s:</p>
-				<pre><code class="language-bash">deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.3.0/opine-cli.ts
+				<pre><code class="language-bash">deno install -f -q --allow-read --allow-write --allow-net --unstable https://deno.land/x/opinecli@1.3.1/opine-cli.ts
 </code></pre>
 				<p>And follow any suggestions to update your <code>PATH</code> environment variable.</p>
 				<p>Create the app:</p>

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "opine",
     "description": "Fast, minimalist web framework for Deno ported from ExpressJS.",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "repository": "https://github.com/asos-craigmorten/opine",
     "stable": true,
     "files": [

--- a/examples/react/server.tsx
+++ b/examples/react/server.tsx
@@ -8,8 +8,8 @@
  * from this repo.
  *
  */
-import { opine, serveStatic } from "https://deno.land/x/opine@1.3.0/mod.ts";
-import { dirname, join } from "https://deno.land/x/opine@1.3.0/deps.ts";
+import { opine, serveStatic } from "https://deno.land/x/opine@1.3.1/mod.ts";
+import { dirname, join } from "https://deno.land/x/opine@1.3.1/deps.ts";
 import { renderFileToString } from "https://deno.land/x/dejs@0.9.3/mod.ts";
 // @deno-types="https://raw.githubusercontent.com/Soremwar/deno_types/4a50660/react/v16.13.1/react.d.ts"
 import React from "https://dev.jspm.io/react@16.13.1";

--- a/version.ts
+++ b/version.ts
@@ -1,7 +1,7 @@
 /**
  * Version of Opine.
  */
-export const VERSION: string = "1.3.0";
+export const VERSION: string = "1.3.1";
 
 /**
  * Supported version of Deno.


### PR DESCRIPTION
# Issue

No issue.

## Details

- ci: downgrade eggs publish to Deno `1.8.3` due to bug in Eggs CLI.

## CheckList

- [ ] PR starts with [#_ISSUE_ID_].
- [ ] Has been tested (where required).
