### PR TITLE
Support for the error ConnectionAborted

### DIFF
--- a/src/response.ts
+++ b/src/response.ts
@@ -257,7 +257,7 @@ export class Response implements DenoResponse {
       await this.req.respond(this);
     } catch (e) {
       // Connection might have been already closed
-      if (!(e instanceof Deno.errors.BadResource)) {
+      if (!(e instanceof Deno.errors.BadResource || e instanceof Deno.errors.ConnectionAborted)) {
         throw e;
       }
     }


### PR DESCRIPTION
## Details

When too many queries are performed in too short a time interval, I would get this error, adding this key support resolves the error.
```sh
error: Uncaught (in promise) ConnectionAborted: An established connection has been abandoned by software from your host computer. (os error 10053)
          numBytesWritten = await this.writer.write(data);
                            ^
    at deno:core/core.js:86:46
    at unwrapOpResult (deno:core/core.js:106:13)
    at async write (deno:runtime/js/12_io.js:107:12)
    at async BufWriter.write (https://deno.land/std@0.97.0/io/bufio.ts:498:29)
    at async writeResponse (https://deno.land/std@0.97.0/http/_io.ts:277:15)
    at async ServerRequest.respond (https://deno.land/std@0.97.0/http/server.ts:87:7)
    at async Response.end (https://deno.land/x/opine@1.4.0/src/response.ts:257:7)
```

## CheckList

- [ ] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
