### PR TITLE
[#126] feat: add setHeader alias for res.set

### DIFF
--- a/.github/API/response.md
+++ b/.github/API/response.md
@@ -570,6 +570,20 @@ res.set({
 });
 ```
 
+#### res.setHeader(field [, value])
+
+An alias for `res.set`
+
+```ts
+res.setHeader("Content-Type", "text/plain");
+
+res.setHeader({
+  "Content-Type", "text/plain; charset=utf-8",
+  "Content-Length": "123",
+  "Cache-control": "no-store",
+});
+```
+
 #### res.setStatus(code)
 
 Sets the HTTP status for the response. It is a chainable alias of Deno's [response.status](https://doc.deno.land/https/deno.land/std/http/mod.ts#Response).

--- a/src/response.ts
+++ b/src/response.ts
@@ -823,6 +823,30 @@ export class Response implements DenoResponse {
   }
 
   /**
+   * Set header `field` to `value`, or pass
+   * an object of header fields.
+   *
+   * alias for res.set()
+   *
+   * Examples:
+   *
+   *     res.setHeader('Accept', 'application/json');
+   *     res.setHeader({
+   *       'Accept-Language': "en-US, en;q=0.5",
+   *       'Accept': 'text/html',
+   *     });
+   * @param {string} field
+   * @param {string} value
+   * @return {Response} for chaining
+   * @public
+   */
+  setHeader(field: string, value: string): this;
+  setHeader(obj: Record<string, string>): this;
+  setHeader(field: unknown, value?: unknown): this {
+    return this.set(field as any, value as any);
+  }
+
+  /**
    * Set status `code`.
    *
    * This method deviates from Express due to the naming clash

--- a/src/types.ts
+++ b/src/types.ts
@@ -923,6 +923,27 @@ export interface Response<ResBody = any>
   set(obj: Record<string, string>): this;
 
   /**
+   * Set header `field` to `value`, or pass
+   * an object of header fields.
+   *
+   * alias for res.set()
+   *
+   * Examples:
+   *
+   *     res.setHeader('Accept', 'application/json');
+   *     res.setHeader({
+   *       'Accept-Language': "en-US, en;q=0.5",
+   *       'Accept': 'text/html',
+   *     });
+   * @param {string} field
+   * @param {string} value
+   * @return {Response} for chaining
+   * @public
+   */
+  setHeader(field: string, value: string): this;
+  setHeader(obj: Record<string, string>): this;
+
+  /**
    * Set status `code`.
    */
   setStatus(code: Status): this;

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,6 +1,6 @@
 export { deferred } from "https://deno.land/std@0.97.0/async/deferred.ts";
 export type { Deferred } from "https://deno.land/std@0.97.0/async/deferred.ts";
-export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
+export { expect, mock } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export { superdeno } from "https://deno.land/x/superdeno@4.2.0/mod.ts";
 export type {
   IRequest as SuperDenoRequest,

--- a/test/units/res.setHeader.test.ts
+++ b/test/units/res.setHeader.test.ts
@@ -1,0 +1,52 @@
+import opine from "../../mod.ts";
+import { describe, it } from "../utils.ts";
+import { expect, mock, superdeno } from "../deps.ts";
+
+describe("res", function () {
+  describe(".setHeader(field, value)", function () {
+    it("should passthrough to .set", function (done) {
+      const app = opine();
+
+      const set = mock.fn(() => undefined);
+      app.use(function (_req, res) {
+        res.set = set;
+        res.setHeader("Content-Type", "text/x-foo; charset=utf-8").end();
+      });
+
+      superdeno(app)
+        .get("/")
+        .end(() => {
+          expect(set).toHaveBeenCalledWith(
+            "Content-Type",
+            "text/x-foo; charset=utf-8",
+          );
+          done();
+        });
+    });
+  });
+
+  describe(".setHeader(object)", function () {
+    it("should passthrough to .set", function (done) {
+      const app = opine();
+
+      const set = mock.fn(() => undefined);
+      app.use(function (_req, res) {
+        res.set = set;
+        res.setHeader({
+          "X-Foo": "bar",
+          "X-Bar": "baz",
+        }).end();
+      });
+
+      superdeno(app)
+        .get("/")
+        .end(() => {
+          expect(set).toHaveBeenCalledWith({
+            "X-Foo": "bar",
+            "X-Bar": "baz",
+          }, undefined);
+          done();
+        });
+    });
+  });
+});


### PR DESCRIPTION
express has a `setHeader` alias used by many packages ie.
[helmet](https://github.com/helmetjs/helmet/blob/079674038e43ec9066368ee7217cfa6a072f863e/middlewares/content-security-policy/index.ts#L253)

# Issue

Fixes #126.

## Details

Simply adds a `res.setHeader` method that passes through to `res.set`, functioning as an alias.

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
