### PR TITLE
[#128] feat: add res.removeHeader

### DIFF
--- a/.github/API/response.md
+++ b/.github/API/response.md
@@ -416,6 +416,14 @@ defaulting to `/` when the referer is missing.
 res.redirect("back");
 ```
 
+#### res.removeHeader(field)
+
+Remove the HTTP response header `field`
+
+```ts
+res.removeHeader('Accept');
+```
+
 #### res.render(view [, locals][, callback])
 
 Renders a `view` and sends the rendered HTML string to the client. Optional parameters:

--- a/.github/API/response.md
+++ b/.github/API/response.md
@@ -418,7 +418,7 @@ res.redirect("back");
 
 #### res.removeHeader(field)
 
-Remove the HTTP response header `field`
+Remove the HTTP response header `field`.
 
 ```ts
 res.removeHeader('Accept');

--- a/src/response.ts
+++ b/src/response.ts
@@ -590,6 +590,21 @@ export class Response implements DenoResponse {
   }
 
   /**
+   * Remove a header from the response
+   *
+   * Examples:
+   *
+   *     res.removeHeader('Accept');
+   * @param {string} field
+   * @return {Response} for chaining
+   * @public
+   */
+  removeHeader(field: string): this {
+    this.headers.has(field) && this.headers.delete(field);
+    return this;
+  }
+
+  /**
    * Render `view` with the given `options` and optional callback `fn`.
    * When a callback function is given a response will _not_ be made
    * automatically, otherwise a response of _200_ and _text/html_ is given.

--- a/src/types.ts
+++ b/src/types.ts
@@ -840,6 +840,18 @@ export interface Response<ResBody = any>
   redirect(code: Status, url: string): void;
 
   /**
+   * Remove a header from the response
+   *
+   * Examples:
+   *
+   *     res.removeHeader('Accept');
+   * @param {string} field
+   * @return {Response} for chaining
+   * @public
+   */
+  removeHeader(field: string): this;
+
+  /**
    * Render `view` with the given `options` and optional callback `fn`.
    * When a callback function is given a response will _not_ be made
    * automatically, otherwise a response of _200_ and _text/html_ is given.

--- a/test/units/res.removeHeader.test.ts
+++ b/test/units/res.removeHeader.test.ts
@@ -1,0 +1,36 @@
+import opine from "../../mod.ts";
+import { describe, it } from "../utils.ts";
+import { superdeno } from "../deps.ts";
+import { expect } from "../deps.ts";
+
+describe("res", function () {
+  describe(".removeHeader(field, value)", function () {
+    it("should remove the response header field", function (done) {
+      const app = opine();
+
+      app.use(function (req, res) {
+        res.set("Content-Type", "text/x-foo; charset=utf-8");
+        res.removeHeader("Content-Type").end();
+      });
+
+      superdeno(app)
+        .get("/")
+        .end((_, res) => {
+          expect(res.header).not.toHaveProperty("Content-Type");
+          done();
+        });
+    });
+
+    it("should do nothing if header is not present", function (done) {
+      const app = opine();
+
+      app.use(function (req, res) {
+        res.removeHeader("Content-Type").end();
+      });
+
+      superdeno(app)
+        .get("/")
+        .expect(200, done);
+    });
+  });
+});

--- a/test/units/res.removeHeader.test.ts
+++ b/test/units/res.removeHeader.test.ts
@@ -4,7 +4,7 @@ import { superdeno } from "../deps.ts";
 import { expect } from "../deps.ts";
 
 describe("res", function () {
-  describe(".removeHeader(field, value)", function () {
+  describe(".removeHeader(field)", function () {
     it("should remove the response header field", function (done) {
       const app = opine();
 


### PR DESCRIPTION
`res.removeHeader` is on node's Response object so not inherently part of express,
but is still exposed by the `express` embellished Response object

# Issue

Fixes #128.

## Details

Adds `removeHeader` method onto `res`

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
