### PR TITLE
[#139] Support Deno 1.13.1 and std 0.105.0

### DIFF
--- a/.github/API/application.md
+++ b/.github/API/application.md
@@ -7,7 +7,7 @@ Adapted from the [ExpressJS API Docs](https://expressjs.com/en/4x/api.html).
 The `app` object conventionally denotes the Opine application. Create it by calling the top-level `opine()` function exported by the Opine module:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -59,7 +59,7 @@ The `app.mountpath` property contains one or more path patterns on which a sub-a
 > A sub-app is an instance of `opine` that may be used for handling the request to a route.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine(); // the main app
 const admin = opine(); // the sub app
@@ -447,7 +447,7 @@ app.get("/", function (req, res) {
 Binds and listens for connections on the specified address. This method is nearly identical to Deno's [http.listenAndServe()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServe). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -477,7 +477,7 @@ Binds and listens for connections on the specified numerical port. If no port is
 This method is supported for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 const PORT = 3000;
@@ -490,7 +490,7 @@ app.listen(PORT, () => console.log(`Server started on port ${PORT}`));
 Binds and listens for connections using the specified [http.HTTPOptions](https://doc.deno.land/https/deno.land/std/http/server.ts#HTTPOptions). This method is nearly identical to Deno's [http.listenAndServe()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServe). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -502,7 +502,7 @@ app.listen({ port: 3000 });
 Binds and listens for connections using the specified [http.HTTPSOptions](https://doc.deno.land/https/deno.land/std/http/server.ts#HTTPSOptions). This method is nearly identical to Deno's [http.listenAndServeTLS()](https://doc.deno.land/https/deno.land/std/http/server.ts#listenAndServeTLS). An optional callback can be provided which will be executed after the server starts listening for requests - this is provided for legacy reasons to aid in transitions from Express on Node.
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 

--- a/.github/API/middlewares.md
+++ b/.github/API/middlewares.md
@@ -13,7 +13,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
-import { opine, json } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine, json } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -47,7 +47,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.toString()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.body` is a string before calling string methods is recommended.
 
 ```ts
-import { opine, raw } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine, raw } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -166,7 +166,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.trim()` may fail in multiple ways, for example stacking multiple parsers `req.body` may be from a different parser. Testing that `req.parsedBody` is a string before calling string methods is recommended.
 
 ```ts
-import { opine, text } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine, text } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -198,7 +198,7 @@ After the middleware, the existing `body` property on the `request` object (i.e.
 > As `req.body` and `req.parsedBody` shapes are based on user-controlled input, all properties and values in this object are untrusted and should be validated before trusting. For example, `req.body.foo.toString()` may fail in multiple ways, for example `foo` may not be there or may not be a string, and `toString` may not be a function and instead a string or other user-input.
 
 ```ts
-import { opine, urlencoded } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine, urlencoded } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 

--- a/.github/API/opine.md
+++ b/.github/API/opine.md
@@ -7,7 +7,7 @@ Adapted from the [ExpressJS API Docs](https://expressjs.com/en/4x/api.html).
 Creates an Opine application. The `opine()` function is a top-level function exported by the Opine module:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 ```
@@ -15,7 +15,7 @@ const app = opine();
 The `opine()` function is also exported as a named export:
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 ```

--- a/.github/API/request.md
+++ b/.github/API/request.md
@@ -84,7 +84,7 @@ import {
   opine,
   json,
   urlencoded,
-} from "https://deno.land/x/opine@1.7.1/mod.ts";
+} from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -100,7 +100,7 @@ app.post("/profile", function (req, res, next) {
 The following example shows how to implement your own simple body-parsing middleware to transform `req.body` into a raw string:
 
 ```ts
-import opine from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 

--- a/.github/API/router.md
+++ b/.github/API/router.md
@@ -11,7 +11,7 @@ A router behaves like middleware itself, so you can use it as an argument to [ap
 Opine has a top-level named function export `Router()` that creates a new `router` object.
 
 ```ts
-import { Router } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { Router } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const router = Router(options);
 ```
@@ -210,7 +210,7 @@ This method is similar to [app.use()](./application#appusepath-callback--callbac
 Middleware is like a plumbing pipe: requests start at the first middleware function defined and work their way "down" the middleware stack processing for each path they match.
 
 ```ts
-import opine, { Router } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import opine, { Router } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 const router = Router();

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## [1.7.2] - 17-08-2021
+
+- feat: support Deno `1.13.1` and std `0.105.0`.
+
 ## [1.7.1] - 08-08-2021
 
 - [#137] Move to skypack for npm deps (#138)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.12.2
+          deno-version: 1.13.1
       - run: |
           mkdir -p artifacts          
           cat > artifacts/message.md <<EOF

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - run: make deps
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.12.2
+          deno-version: 1.13.1
       - run: make typedoc
       - run: make ci
       - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/publish-egg.yml
+++ b/.github/workflows/publish-egg.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: denolib/setup-deno@v2
         with:
-          deno-version: 1.12.2
+          deno-version: 1.13.1
       - run: deno install -A -f --unstable -n eggs https://x.nest.land/eggs@0.3.8/eggs.ts
       - run: |
           export PATH="/home/runner/.deno/bin:$PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        deno-version: [1.12.2]
+        deno-version: [1.13.1]
 
     runs-on: ${{ matrix.os }}
 
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        deno-version: [1.12.2]
+        deno-version: [1.13.1]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Fast, minimalist web framework for <a href="https://deno.land/">Deno</a> ported 
 </p>
 <p align="center">
    <a href="https://deno.land/x/opine"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fopine%2Fmod.ts" alt="Opine latest /x/ version" /></a>
-   <a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-1.12.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
+   <a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-1.13.1-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opine/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fx%2Fopine%2Fmod.ts" alt="Opine dependency count" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opine/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fupdates%2Fx%2Fopine%2Fmod.ts" alt="Opine dependency outdatedness" /></a>
    <a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opine/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fcache-size%2Fx%2Fopine%2Fmod.ts" alt="Opine cached size" /></a>
@@ -41,7 +41,7 @@ Fast, minimalist web framework for <a href="https://deno.land/">Deno</a> ported 
 ## Getting Started
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.7.2/mod.ts";
 
 const app = opine();
 
@@ -61,13 +61,13 @@ Before importing, [download and install Deno](https://deno.land/#installation).
 You can then import Opine straight into your project:
 
 ```ts
-import { opine } from "https://deno.land/x/opine@1.7.1/mod.ts";
+import { opine } from "https://deno.land/x/opine@1.7.2/mod.ts";
 ```
 
 Opine is also available on [nest.land](https://nest.land/package/opine), a package registry for Deno on the Blockchain.
 
 ```ts
-import { opine } from "https://x.nest.land/opine@1.7.1/mod.ts";
+import { opine } from "https://x.nest.land/opine@1.7.2/mod.ts";
 ```
 
 ## Features

--- a/deps.ts
+++ b/deps.ts
@@ -3,21 +3,21 @@ export {
   Server,
   ServerRequest,
   serveTLS,
-} from "https://deno.land/std@0.103.0/http/server.ts";
+} from "https://deno.land/std@0.105.0/http/server.ts";
 export type {
   HTTPOptions,
   HTTPSOptions,
   Response,
-} from "https://deno.land/std@0.103.0/http/server.ts";
+} from "https://deno.land/std@0.105.0/http/server.ts";
 export {
   Status,
   STATUS_TEXT,
-} from "https://deno.land/std@0.103.0/http/http_status.ts";
+} from "https://deno.land/std@0.105.0/http/http_status.ts";
 export {
   deleteCookie,
   setCookie,
-} from "https://deno.land/std@0.103.0/http/cookie.ts";
-export type { Cookie } from "https://deno.land/std@0.103.0/http/cookie.ts";
+} from "https://deno.land/std@0.105.0/http/cookie.ts";
+export type { Cookie } from "https://deno.land/std@0.105.0/http/cookie.ts";
 export {
   basename,
   dirname,
@@ -28,18 +28,18 @@ export {
   normalize,
   resolve,
   sep,
-} from "https://deno.land/std@0.103.0/path/mod.ts";
-export { setImmediate } from "https://deno.land/std@0.103.0/node/timers.ts";
-export { parse } from "https://deno.land/std@0.103.0/node/querystring.ts";
-export { default as EventEmitter } from "https://deno.land/std@0.103.0/node/events.ts";
-export { Sha1 } from "https://deno.land/std@0.103.0/hash/sha1.ts";
+} from "https://deno.land/std@0.105.0/path/mod.ts";
+export { setImmediate } from "https://deno.land/std@0.105.0/node/timers.ts";
+export { parse } from "https://deno.land/std@0.105.0/node/querystring.ts";
+export { default as EventEmitter } from "https://deno.land/std@0.105.0/node/events.ts";
+export { Sha1 } from "https://deno.land/std@0.105.0/hash/sha1.ts";
 export {
   charset,
   contentType,
   lookup,
-} from "https://deno.land/x/media_types@v2.9.1/mod.ts";
+} from "https://deno.land/x/media_types@v2.10.1/mod.ts";
 export { createError } from "https://deno.land/x/http_errors@3.0.0/mod.ts";
-export { Accepts } from "https://deno.land/x/accepts@2.1.0/mod.ts";
+export { Accepts } from "https://deno.land/x/accepts@2.1.1/mod.ts";
 export {
   hasBody,
   typeofrequest,

--- a/docs/index.html
+++ b/docs/index.html
@@ -82,7 +82,7 @@
 				</p>
 				<p align="center">
 					<a href="https://deno.land/x/opine"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Flatest-version%2Fx%2Fopine%2Fmod.ts" alt="Opine latest /x/ version" /></a>
-					<a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-1.12.2-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
+					<a href="https://github.com/denoland/deno/blob/main/Releases.md"><img src="https://img.shields.io/badge/deno-1.13.1-brightgreen?logo=deno" alt="Minimum supported Deno version" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opine/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fdep-count%2Fx%2Fopine%2Fmod.ts" alt="Opine dependency count" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opine/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fupdates%2Fx%2Fopine%2Fmod.ts" alt="Opine dependency outdatedness" /></a>
 					<a href="https://deno-visualizer.danopia.net/dependencies-of/https/deno.land/x/opine/mod.ts"><img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fdeno-visualizer.danopia.net%2Fshields%2Fcache-size%2Fx%2Fopine%2Fmod.ts" alt="Opine cached size" /></a>
@@ -105,7 +105,7 @@
 				<a href="#getting-started" id="getting-started" style="color: inherit; text-decoration: none;">
 					<h2>Getting Started</h2>
 				</a>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.7.1/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.7.2/mod.ts&quot;</span>;
 
 <span class="hljs-keyword">const</span> app = opine();
 
@@ -121,10 +121,10 @@ app.listen(<span class="hljs-number">3000</span>, <span class="hljs-function">()
 				<p>This is a <a href="https://deno.land/">Deno</a> module available to import direct from this repo and via the <a href="https://deno.land/x">Deno Registry</a>.</p>
 				<p>Before importing, <a href="https://deno.land/#installation">download and install Deno</a>.</p>
 				<p>You can then import Opine straight into your project:</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.7.1/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://deno.land/x/opine@1.7.2/mod.ts&quot;</span>;
 </code></pre>
 				<p>Opine is also available on <a href="https://nest.land/package/opine">nest.land</a>, a package registry for Deno on the Blockchain.</p>
-				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/opine@1.7.1/mod.ts&quot;</span>;
+				<pre><code class="language-ts"><span class="hljs-keyword">import</span> { opine } <span class="hljs-keyword">from</span> <span class="hljs-string">&quot;https://x.nest.land/opine@1.7.2/mod.ts&quot;</span>;
 </code></pre>
 				<a href="#features" id="features" style="color: inherit; text-decoration: none;">
 					<h2>Features</h2>

--- a/egg.json
+++ b/egg.json
@@ -1,7 +1,7 @@
 {
     "name": "opine",
     "description": "Fast, minimalist web framework for Deno ported from ExpressJS.",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "repository": "https://github.com/asos-craigmorten/opine",
     "stable": true,
     "checkFormat": false,

--- a/examples/react/components/App.tsx
+++ b/examples/react/components/App.tsx
@@ -4,16 +4,22 @@ import { List } from "./List.tsx";
 
 export const App = ({ isServer = false }) => {
   if (isServer) {
-    return (<>
-      <Title />
-      <p className="app_loading">Loading Doggos...</p>
-    </>);
+    return (
+      <>
+        <Title />
+        <p className="app_loading">Loading Doggos...</p>
+      </>
+    );
   }
 
-  return (<>
-    <Title />
-    <React.Suspense fallback={<p className="app_loading">Loading Doggos...</p>}>
-      <List />
-    </React.Suspense>
-  </>);
+  return (
+    <>
+      <Title />
+      <React.Suspense
+        fallback={<p className="app_loading">Loading Doggos...</p>}
+      >
+        <List />
+      </React.Suspense>
+    </>
+  );
 };

--- a/examples/react/components/List.tsx
+++ b/examples/react/components/List.tsx
@@ -10,7 +10,9 @@ export const List = () => {
   return (
     <section className="list_section">
       <ol className="list_list">
-        {doggos.map((doggo: { id: number; src: string; alt: string }) => (
+        {doggos.map((
+          doggo: { id: number; src: string; alt: string },
+        ) => (
           <li className="list_tile" key={doggo.id}>
             <a className="list_card" href={doggo.src}>
               <div className="list_image_container">

--- a/examples/react/components/Title.tsx
+++ b/examples/react/components/Title.tsx
@@ -1,6 +1,7 @@
 import React from "https://esm.sh/react@17.0.2?dev";
 
-export const Title = () =>
+export const Title = () => (
   <header className="title_header">
     <h1 className="title_text">Deno Doggo List</h1>
-  </header>;
+  </header>
+);

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,5 +1,5 @@
-export { deferred } from "https://deno.land/std@0.103.0/async/deferred.ts";
-export type { Deferred } from "https://deno.land/std@0.103.0/async/deferred.ts";
+export { deferred } from "https://deno.land/std@0.105.0/async/deferred.ts";
+export type { Deferred } from "https://deno.land/std@0.105.0/async/deferred.ts";
 export { expect, mock } from "https://deno.land/x/expect@v0.2.9/mod.ts";
 export { superdeno } from "https://deno.land/x/superdeno@4.4.0/mod.ts";
 export type {

--- a/version.ts
+++ b/version.ts
@@ -1,9 +1,9 @@
 /**
  * Version of Opine.
  */
-export const VERSION = "1.7.1";
+export const VERSION = "1.7.2";
 
 /**
  * Supported version of Deno.
  */
-export const DENO_SUPPORTED_VERSIONS: string[] = ["1.12.2"];
+export const DENO_SUPPORTED_VERSIONS: string[] = ["1.13.1"];


### PR DESCRIPTION
# Issue

Fixes #139.

## Details

- ci: upgrade to Deno `1.13.1`
- deps: upgrade to `std@0.105.0`
- deps: upgrade to `media_types@v2.10.1` and `accepts@2.1.1`

## CheckList

- [x] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required).
